### PR TITLE
style: responsive styling and CSS fixes for recipe detail page

### DIFF
--- a/src/pages/RecipeDetailPage.css
+++ b/src/pages/RecipeDetailPage.css
@@ -353,6 +353,10 @@
     .more-recipes-grid > * {
         flex: 0 0 400px;
     }
+
+    .more-recipes-content {
+        padding: 0;
+    }
 }
 
 @media (max-width: 480px) {

--- a/src/pages/RecipeDetailPage.css
+++ b/src/pages/RecipeDetailPage.css
@@ -19,9 +19,9 @@
 }
 
 /* HERO */
-.hero {
+.recipe-hero {
     display: flex;
-    gap: var(--spacing-xl);
+    gap: var(--spacing-lg);
     align-items: flex-end;
 }
 
@@ -31,7 +31,7 @@
 
 .hero-img-wrapper img {
     width: 400px;
-    height: 450px;
+    height: 500px;
     object-fit: cover;
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-lg);
@@ -42,6 +42,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacing-md);
+    min-width: 400px;
     width: 100%;
 }
 
@@ -246,13 +247,14 @@
 /* MORE RECIPES */
 .more-recipes {
     background-color: var(--color-border);
-    padding: var(--spacing-xl);
+    padding: var(--spacing-xl) 0;
     margin-top: var(--spacing-xl);
 }
 
 .more-recipes-content {
     max-width: var(--container-max-width);
     margin: 0 auto;
+    padding: 0 var(--spacing-xl);
 }
 
 .more-recipes-content > h2 {
@@ -263,6 +265,10 @@
 .more-recipes-grid {
     display: flex;
     gap: var(--spacing-xl);
+}
+
+.more-recipes-grid > * {
+    flex: 1;
 }
 
 /* 404 - NOT FOUND */
@@ -310,9 +316,15 @@
 
 /* RESPONSIVE */
 @media (max-width: 768px) {
-    .hero {
+    .recipe-hero {
         flex-direction: column;
         align-items: stretch;
+        padding: var(--spacing-md);
+    }
+
+    .hero-info {
+        min-width: unset;
+        width: 100%;
     }
 
     .hero-img-wrapper {
@@ -321,7 +333,7 @@
 
     .hero-img-wrapper img {
         width: 100%;
-        height: 300px;
+        height: 350px;
     }
 
     .recipe-content {
@@ -334,7 +346,12 @@
     }
 
     .more-recipes-grid {
-        flex-direction: column;
+        overflow-x: auto;
+        padding: 0 var(--spacing-lg) var(--spacing-sm) var(--spacing-lg);
+    }
+
+    .more-recipes-grid > * {
+        flex: 0 0 400px;
     }
 }
 
@@ -387,5 +404,17 @@
         min-width: 1.5rem;
         height: 1.5rem;
         font-size: var(--text-caption);
+    }
+}
+
+@media (max-width: 375px) {
+    .recipe-hero {
+        padding: var(--spacing-xs);
+    }
+}
+
+@media (max-width: 320px) {
+    .info-item p {
+        font-size: var(--text-body);
     }
 }

--- a/src/pages/RecipeDetailPage.jsx
+++ b/src/pages/RecipeDetailPage.jsx
@@ -69,7 +69,7 @@ function RecipeDetailPage() {
                 </button>
 
                 {/* Hero-sektion med bild och grundläggande receptinfo */}
-                <section className='hero'>
+                <section className='recipe-hero'>
                     <div className='hero-img-wrapper'>
                         <img
                         src={recipe.strMealThumb}


### PR DESCRIPTION
## Recipe Detail Page – Responsivitet och CSS-fixar

### Vad som lagts till/fixats
- Responsiv layout för hero, info-kort, ingredienser och instruktioner
- Horisontell scroll för More Recipes-korten på tablet och mobil
- Info-kort får korrekt bredd på alla skärmstorlekar
- Lång recepttitel hanteras snyggt utan att layouten bryts
- More Recipes-korten centreras korrekt på tablet
- Döpte om .hero till .recipe-hero för att undvika CSS-konflikt 
  med LandingPage

### Brytpunkter
- 768px – tablet
- 480px – mobil
- 375px – liten mobil
- 320px – mycket liten mobil

### Notering
Receptkortens interna responsivitet behöver fixas i RecipeCard.css 
– tas i en separat branch