### PR TITLE
Feature/zustand catching

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, ScrollRestoration } from "react-router-dom";
 import "./App.css";
 
 // Sidor

--- a/src/api/mealdb.js
+++ b/src/api/mealdb.js
@@ -3,6 +3,7 @@
 // Använder vi ett till API, gör en ny fil med API:ets namn 
 
 import { useEffect, useState } from "react";
+import useSearchStore from "../stores/useSearchStore";
 
 const API_BASE = "https://www.themealdb.com/api/json/v1/1";
 
@@ -87,6 +88,8 @@ export function useRecipesByCategory(category) {
   const [recipes, setRecipes] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const categoryCache = useSearchStore((state) => state.categoryCache);
+  const setCategoryCache = useSearchStore((state) => state.setCategoryCache);
 
   useEffect(() => {
     const fetchRecipes = async () => {
@@ -101,17 +104,18 @@ export function useRecipesByCategory(category) {
         }
 
         const data = await response.json();
-          console.log(data.meals[0])
+        console.log(data.meals[0])
 
-       const fullRecipes = await Promise.all(
-        data.meals.map(async (meal) => {
-          const res = await fetch(`${API_BASE}/lookup.php?i=${meal.idMeal}`);
-          const detail = await res.json();
-          return detail.meals[0];
-        })
-       );
-       setRecipes(fullRecipes);
-       
+        const fullRecipes = await Promise.all(
+          data.meals.map(async (meal) => {
+            const res = await fetch(`${API_BASE}/lookup.php?i=${meal.idMeal}`);
+            const detail = await res.json();
+            return detail.meals[0];
+          })
+        );
+        setRecipes(fullRecipes);
+        setCategoryCache(category, fullRecipes);
+
       } catch (err) {
         setError(err.message);
       } finally {
@@ -119,7 +123,11 @@ export function useRecipesByCategory(category) {
       }
     };
 
-    fetchRecipes();
+    if (categoryCache[category]) {
+      setRecipes(categoryCache[category]);
+    } else {
+      fetchRecipes();
+    }
   }, [category]);
 
   return { recipes, loading, error };

--- a/src/api/mealdb.js
+++ b/src/api/mealdb.js
@@ -117,7 +117,7 @@ export function useRecipesByCategory(category) {
           })
         );
         setRecipes(fullRecipes);
-        setCategoryCache(category, fullRecipes);
+        setCategoryCache(category, fullRecipes, data.meals);
 
       } catch (err) {
         setError(err.message);
@@ -127,7 +127,8 @@ export function useRecipesByCategory(category) {
     };
 
     if (categoryCache[category]) {
-      setRecipes(categoryCache[category]);
+      setRecipes(categoryCache[category].recipes);
+      setAllMealsIds(categoryCache[category].allMealsIds);
     } else {
       fetchRecipes();
     }

--- a/src/api/mealdb.js
+++ b/src/api/mealdb.js
@@ -90,6 +90,7 @@ export function useRecipesByCategory(category) {
   const [error, setError] = useState(null);
   const categoryCache = useSearchStore((state) => state.categoryCache);
   const setCategoryCache = useSearchStore((state) => state.setCategoryCache);
+  const [allMealsIds, setAllMealsIds] = useState([]);
 
   useEffect(() => {
     const fetchRecipes = async () => {
@@ -104,10 +105,12 @@ export function useRecipesByCategory(category) {
         }
 
         const data = await response.json();
+        setAllMealsIds(data.meals);
+        const first15 = data.meals.slice(0, 15);
         console.log(data.meals[0])
 
         const fullRecipes = await Promise.all(
-          data.meals.map(async (meal) => {
+          first15.map(async (meal) => {
             const res = await fetch(`${API_BASE}/lookup.php?i=${meal.idMeal}`);
             const detail = await res.json();
             return detail.meals[0];
@@ -130,7 +133,20 @@ export function useRecipesByCategory(category) {
     }
   }, [category]);
 
-  return { recipes, loading, error };
+  const fetchMore = async () => {
+    const nextBatch = allMealsIds.slice(recipes.length, recipes.length + 15);
+    const newRecipes = await Promise.all(
+      nextBatch.map(async (meal) => {
+        const res = await fetch(`${API_BASE}/lookup.php?i=${meal.idMeal}`);
+        const detail = await res.json();
+        return detail.meals[0];
+      })
+    );
+
+    setRecipes([...recipes, ...newRecipes]);
+  }
+
+  return { recipes, loading, error, allMealsIds, fetchMore };
 }
 
 /**

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -13,14 +13,11 @@ function LandingPage() {
   const { recipe, loading, error } = useRandomRecipe();
   const searchResults = useSearchStore((state) => state.searchResults);
   const activeFilter = useSearchStore((state) => state.activeFilter);
-  const { recipes, error: recipesError, loading: recipesLoading } = useRecipesByCategory(activeFilter);
+  const { recipes, error: recipesError, loading: recipesLoading, fetchMore, allMealsIds } = useRecipesByCategory(activeFilter);
   const setActiveFilter = useSearchStore((state) => state.setActiveFilter);
   const [hasSearched, setHasSearched] = useState(false);
   const navigate = useNavigate();
-  const [visibleCount, setVisibleCount] = useState(15);
-  const visibleRecipes = (
-    hasSearched ? filterRecipes(searchResults, activeFilter) : recipes
-  ).slice(0, visibleCount);
+  const visibleRecipes = hasSearched ? filterRecipes(searchResults, activeFilter) : recipes;;
 const [showLoading, setShowLoading] = useState(false);
 const featuredRecipe = useSearchStore((state) => state.featuredRecipe);
 const setFeaturedRecipe = useSearchStore((state) => state.setFeaturedRecipe);
@@ -147,7 +144,7 @@ useEffect(() => {
         <h2 className="recipe-category">{activeFilter} recipes</h2>
         <p className="recipe-count">
           {
-            (hasSearched ? filterRecipes(searchResults, activeFilter) : recipes)
+            (hasSearched ? filterRecipes(searchResults, activeFilter) : allMealsIds)
               .length
           }{" "}
           recipes
@@ -168,17 +165,13 @@ useEffect(() => {
         ))}
       </div>
 
-      {/* Kollar ifall listan med recept är längre än 15, om den är det visas Show More knappen. om inte visas knappen inte */}
-      {/* När knappen klickas ökas visibleCount med 15 och visar därmed 15 recept till */}
-      {visibleCount <
-        (hasSearched ? filterRecipes(searchResults, activeFilter) : recipe)
-          .length && (
+      {/* show more knappen visas om det finns mer än 15 recept att hämtas */}
+      {/* recipes.length är hur många recept som hämtats, 15, 30, 45 osv */}
+      {recipes.length < allMealsIds.length && (
         <button
-          className="show-more-btn"
-          onClick={() => setVisibleCount(visibleCount + 15)}
-        >
-          Show More
-        </button>
+        className="show-more-btn"
+        onClick={fetchMore}
+        >Show More</button>
       )}
     </>
   );

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -22,6 +22,9 @@ function LandingPage() {
     hasSearched ? filterRecipes(searchResults, activeFilter) : recipes
   ).slice(0, visibleCount);
 const [showLoading, setShowLoading] = useState(false);
+const featuredRecipe = useSearchStore((state) => state.featuredRecipe);
+const setFeaturedRecipe = useSearchStore((state) => state.setFeaturedRecipe);
+const displayedRecipe = featuredRecipe ?? recipe;
 
 // Loading-meddelande visas först efter 500ms
 useEffect(() => {
@@ -32,6 +35,14 @@ useEffect(() => {
         setShowLoading(false);
     }
 }, [recipesLoading]);
+
+  useEffect(() => {
+    if (recipe && !featuredRecipe) {
+        setFeaturedRecipe(recipe) 
+    } 
+    
+  }, [recipe, featuredRecipe])
+
 
   if (recipe) console.log(recipe);
 
@@ -54,11 +65,11 @@ useEffect(() => {
       <div className="hero">
         <div className="hero-text">
           <p className="featured-recipes">FEATURED RECIPES</p>
-          <h1 className="header-h1">{recipe.strMeal}</h1>
+          <h1 className="header-h1">{displayedRecipe.strMeal}</h1>
           <div className="header-icons">
             <span className="category-icon">
               <Tag size={16} />
-              {recipe.strCategory}
+              {displayedRecipe.strCategory}
             </span>
             <span className="servings-icon">
               <Users size={16} /> {"4 servings"}
@@ -88,7 +99,7 @@ useEffect(() => {
           {/* TODO: länka till receptsida när den är klar */}
           <button
             className="view-recipe-btn"
-            onClick={() => navigate(`/recipe/${recipe.idMeal}`)}
+            onClick={() => navigate(`/recipe/${displayedRecipe.idMeal}`)}
           >
             View Recipe
             <span>
@@ -97,7 +108,7 @@ useEffect(() => {
           </button>
         </div>
         <div>
-          <img className="hero-img" src={recipe.strMealThumb} />
+          <img className="hero-img" src={displayedRecipe.strMealThumb} />
         </div>
       </div>
 
@@ -160,7 +171,7 @@ useEffect(() => {
       {/* Kollar ifall listan med recept är längre än 15, om den är det visas Show More knappen. om inte visas knappen inte */}
       {/* När knappen klickas ökas visibleCount med 15 och visar därmed 15 recept till */}
       {visibleCount <
-        (hasSearched ? filterRecipes(searchResults, activeFilter) : recipes)
+        (hasSearched ? filterRecipes(searchResults, activeFilter) : recipe)
           .length && (
         <button
           className="show-more-btn"

--- a/src/stores/useSearchStore.js
+++ b/src/stores/useSearchStore.js
@@ -34,8 +34,8 @@ const useSearchStore = create((set) => ({
     setFeaturedRecipe: (recipe) => set({ featuredRecipe: recipe }),
 
 
-    setCategoryCache: (category, recipes) => set((state) => ({
-        categoryCache: { ...state.categoryCache, [category]: recipes }
+    setCategoryCache: (category, recipes, allMealsIds) => set((state) => ({
+        categoryCache: { ...state.categoryCache, [category]: {recipes, allMealsIds } }
     }))
 }))
 

--- a/src/stores/useSearchStore.js
+++ b/src/stores/useSearchStore.js
@@ -8,6 +8,8 @@ const useSearchStore = create((set) => ({
     searchTerm: '',
     activeFilter: 'Breakfast',
     searchResults: [],
+    featuredRecipe: null,
+    categoryCache: {},
 
     // Uppdaterar söktermen
     setSearchTerm: (term) => {
@@ -27,7 +29,14 @@ const useSearchStore = create((set) => ({
     // Återställer sökning, filter och resultat till ursprungsläget
     resetSearch: () => {
         set({ searchTerm: '', activeFilter: 'Breakfast', searchResults: [] })
-    }
+    },
+
+    setFeaturedRecipe: (recipe) => set({ featuredRecipe: recipe }),
+
+
+    setCategoryCache: (category, recipes) => set((state) => ({
+        categoryCache: { ...state.categoryCache, [category]: recipes }
+    }))
 }))
 
 export default useSearchStore


### PR DESCRIPTION
- Featured recipe (hero-sektionen) sparas nu i Zustand-storen så att samma recept visas när man navigerar tillbaka till landingpagen
- Kategori-recept cachas nu i Zustand-storen per kategori, vilket minskar onödiga API-anrop när man byter mellan kategorier
- Recept hämtas nu i omgångar om 15 istället för alla på en gång, vilket förhindrar att man blir blockad från API:et
- "Show More"-knappen hämtar nästa 15 recept vid klick
- Recepträknaren visar nu det totala antalet recept i kategorin, inte bara de som laddats
- Felhantering för receptladdning med användarvänliga meddelanden