### PR TITLE
fix: scaling recipe card and responsive recipe detail page on tablet …

### DIFF
--- a/src/components/RecipeCard/RecipeCard.css
+++ b/src/components/RecipeCard/RecipeCard.css
@@ -14,7 +14,7 @@
 .card-header {
   position: relative;
   width: 100%;
-  height: 260px;
+  aspect-ratio: 3 / 2;     /* Gör att bilden alltid blir 1.5x bredare än hög - Maryam */
 }
 
 .card-image {

--- a/src/components/RecipeCard/RecipeCard.jsx
+++ b/src/components/RecipeCard/RecipeCard.jsx
@@ -90,7 +90,7 @@ const RecipeCard = ({ recipe }) => {
               <Globe size={16} /> {recipe.strArea}
             </span>
             <span className="icon-text">
-              <Users size={16} /> {"4 servings"}
+              <Users size={16} /> {"4"}
             </span>
           </div>
           <span className="difficulty-tag">

--- a/src/pages/RecipeDetailPage.css
+++ b/src/pages/RecipeDetailPage.css
@@ -315,12 +315,41 @@
 }
 
 /* RESPONSIVE */
-@media (max-width: 768px) {
+@media (max-width: 900px) {
     .recipe-hero {
         flex-direction: column;
         align-items: stretch;
         padding: var(--spacing-md);
     }
+
+    .hero-img-wrapper img {
+        width: 100%;
+        max-width: 100%;
+        height: 400px;
+    }
+
+    .hero-info {
+        min-width: unset;
+        width: 100%;
+    }
+
+    .more-recipes-grid {
+        overflow-x: auto;
+        flex-wrap: nowrap;
+        padding: 0 var(--spacing-lg) var(--spacing-sm) var(--spacing-lg);
+        -webkit-overflow-scrolling: touch; /* smidigare scroll på iOS */
+    }
+
+    .more-recipes-grid > * {
+        flex: 0 0 320px;      /* varje kort blir exakt 320px brett och krymper inte */
+    }
+
+    .more-recipes-content {
+        padding: 0;         /* låter scroll gå ända ut till kanten */
+    }
+}
+
+@media (max-width: 768px) {
 
     .hero-info {
         min-width: unset;
@@ -343,19 +372,6 @@
     .ingredient-list,
     .instructions-list {
         width: 100%;
-    }
-
-    .more-recipes-grid {
-        overflow-x: auto;
-        padding: 0 var(--spacing-lg) var(--spacing-sm) var(--spacing-lg);
-    }
-
-    .more-recipes-grid > * {
-        flex: 0 0 400px;
-    }
-
-    .more-recipes-content {
-        padding: 0;
     }
 }
 


### PR DESCRIPTION
…and mid-size screens

## Responsiv layout på receptdetaljsidan

### Vad som åtgärdats
- Receptkorten i More Recipes blev för smala och höga på tablet och mellanstora skärmar
- More Recipes-sektionens bakgrund sträckte sig inte ut till full bredd
- Hero-sektionen orsakade horisontell overflow vid ~860px vilket bröt hela sidlayouten

### Hur det fungerar
Tre separata CSS-problem identifierades och åtgärdades:

**RecipeCard.css** – ersatte hårdkodad `height: 260px` på `.card-header` med `aspect-ratio: 3/2` så att korten alltid håller rätt proportioner oavsett bredd

**Mediaqueries** – `@media (max-width: 900px)` satte `display: grid` medan `@media (max-width: 768px)` försökte lägga till horisontell flex-scroll – grid och flex-scroll fungerar inte ihop och skapade en kaskadkonflikt. Slogs ihop till en enda 900px-regel med flex

**Hero-overflow** – `.hero-info` hade `min-width: 400px` och hero-bilden hade `max-width: none`, vilket tillsammans var bredare än skärmen vid ~860px. Båda togs bort och hero kollapsar nu till en kolumn vid 900px istället för 768px