### PR TITLE
fix(responsive): improve recipe card layout on landing page and more …

### DIFF
--- a/src/components/RecipeCard/RecipeCard.css
+++ b/src/components/RecipeCard/RecipeCard.css
@@ -2,7 +2,7 @@
 
 .recipe-card {
   width: 100%;
-  max-width: 384px;
+  max-width: 300px;
   background: var(--color-card);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);

--- a/src/index.css
+++ b/src/index.css
@@ -49,6 +49,7 @@
   --line-height-loose: 1.6;
 
   /*  AVSTÅND  */
+  --spacing-xxs: 0.125rem; /* 2px */
   --spacing-xs: 0.25rem; /* 4px */
   --spacing-sm: 0.5rem; /* 8px */
   --spacing-md: 1rem; /* 16px */

--- a/src/pages/LandingPage.css
+++ b/src/pages/LandingPage.css
@@ -86,7 +86,6 @@
     justify-content: center;
     background-color: var(--color-card);
     border: 1px solid var(--color-border);
-
 }
 
 .searchbar {
@@ -136,7 +135,7 @@
     flex-direction: row;
     justify-content: center;
     gap: var(--radius-xl);
-    margin: var(--spacing-2xl);
+    margin: var(--spacing-2xl) auto;
 }
 
 .category-btn.active {
@@ -153,6 +152,7 @@
     margin: 0 auto;
     margin-bottom: var(--spacing-xl);
     margin-top: var(--spacing-3xl);
+    padding: 0 var(--spacing-xl);
 }
 
 
@@ -165,7 +165,6 @@
     max-width: 1300px;
     margin: 0 auto;
     margin-bottom: var(--spacing-2xl);
-
 }
 
 .recipe-cards .recipe-card {
@@ -186,14 +185,22 @@
 }
 
 /* RESPONSIVE */
+@media (max-width: 900px) {
+    .recipe-cards .recipe-card {
+        width: calc(50% - var(--spacing-lg));
+    }
+}
+
 @media (max-width: 768px) {
     .hero {
-        gap: var(--spacing-xl);
+        overflow: hidden;
+        padding: var(--spacing-xl);
     }
 
     .hero-img {
-        height: 400px;
+        height: 350px;
         width: 100%;
+        max-width: 100%;
     }
 
     .searchbar {
@@ -203,16 +210,16 @@
 
     .category-btns {
         flex-wrap: wrap;
+        gap: var(--spacing-sm);
+        margin: var(--spacing-lg) auto;
+        padding: 0 var(--spacing-md);
+        width: 100%;
+        box-sizing: border-box;
     }
 
     .recipe-list-header {
         padding: 0 var(--spacing-lg);
     }
-
-    .recipe-cards .recipe-card {
-        width: calc(50% - var(--spacing-lg));
-    }
-
 }
 
 @media (max-width: 650px) {
@@ -225,9 +232,7 @@
     .hero {
         flex-direction: column;
         padding: var(--spacing-sm);
-        
     }
-
 
     .hero-img {
         height: 400px;
@@ -245,7 +250,7 @@
     }
 
     .featured-recipes {
-        margin-top: var(--spacing-2xl)
+        margin-top: var(--spacing-2xl);
     }
 
     .searchbar {
@@ -254,10 +259,9 @@
     }
 
     .category-btns {
-        margin-top: var(--spacing-2xl);
-        margin: var(--spacing-2xl) var(--spacing-sm);
+        margin: var(--spacing-xl) auto;
+        padding: 0 var(--spacing-md);
     }
-
 
     .recipe-cards .recipe-card {
         width: 100%;
@@ -265,7 +269,6 @@
 }
 
 @media (max-width: 375px) {
-
     .recipe-list-header {
         padding: 0 var(--spacing-sm);
         max-width: 100%;
@@ -277,5 +280,5 @@
 }
 
 @media (max-width: 320px) {
-    
+
 }

--- a/src/pages/RecipeDetailPage.css
+++ b/src/pages/RecipeDetailPage.css
@@ -269,6 +269,7 @@
 
 .more-recipes-grid > * {
     flex: 1;
+    max-width: none;
 }
 
 /* 404 - NOT FOUND */
@@ -336,12 +337,14 @@
     .more-recipes-grid {
         overflow-x: auto;
         flex-wrap: nowrap;
-        padding: 0 var(--spacing-lg) var(--spacing-sm) var(--spacing-lg);
+        padding: 0 var(--spacing-md) var(--spacing-sm) var(--spacing-md);
+        gap: var(--spacing-md);
         -webkit-overflow-scrolling: touch; /* smidigare scroll på iOS */
     }
 
     .more-recipes-grid > * {
-        flex: 0 0 320px;      /* varje kort blir exakt 320px brett och krymper inte */
+        flex: 0 0 300px;      /* varje kort blir exakt 320px brett och krymper inte */
+        max-width: none;
     }
 
     .more-recipes-content {
@@ -431,10 +434,19 @@
     .recipe-hero {
         padding: var(--spacing-xs);
     }
+
+    .more-recipes-grid {
+        padding: 0 var(--spacing-xs) var(--spacing-xs) var(--spacing-xs);
+        gap: var(--spacing-xs);
+    }
 }
 
 @media (max-width: 320px) {
     .info-item p {
         font-size: var(--text-body);
+    }
+
+    .more-recipes-grid {
+        gap: var(--spacing-xxs);
     }
 }


### PR DESCRIPTION
…recipes grid

## Responsiv layout för receptkort på Landing Page och More Recipes-gridet

### Vad som åtgärdats
- Receptkorten på Landing Page staplade sig för tidigt istället för att ligga bredvid varandra
- `.category-btns` orsakade horisontell scroll och sträckte ut sig för långt på mindre skärmar
- Receptkorten i More Recipes-gridet hade för stort mellanrum på små skärmar
- `recipe-list-header` hamnade för långt ut på sidan mellan 1220px och 768px

### Ändringar
**LandingPage.css**
- Lade till `@media (max-width: 900px)` för två kort per rad på mellanstora skärmar
- Fixade `.category-btns` som stack ut utanför skärmen pga `margin: var(--spacing-2xl)` på alla sidor
- Lade till `width: 300px` på receptkorten så att minst tre får plats per rad på laptop
- Lade till `padding: 0 var(--spacing-xl)` på `.recipe-list-header` i grundstilen
- Städade upp dubbla `.category-btns`-regler och rättade ordningen på mediaqueries

**RecipeDetailPage.css**
- Minskade gap mellan receptkorten i More Recipes-gridet på små skärmar
- Lade till `gap: var(--spacing-xxs)` på 320px för tightare layout
- Lade till `max-width: none` på `.more-recipes-grid > *` så korten inte begränsas

**index.css**
- Lade till `--spacing-xxs: 0.125rem` (2px) för extra litet gap på minsta skärmar