### PR TITLE
refactor(store): replace searchInput with hasSearched in useSearchStore

### DIFF
--- a/src/stores/useSearchStore.js
+++ b/src/stores/useSearchStore.js
@@ -6,13 +6,13 @@ import { create } from "zustand";
  */
 const useSearchStore = create((set) => ({
     searchTerm: '',
+    hasSearched: false,
     activeFilter: 'Breakfast',
     searchResults: [],
     featuredRecipe: null,
     categoryCache: {},
-    searchInput: '',
 
-    // Uppdaterar söktermen
+    // Uppdaterar söktermen som skickas till API:et
     setSearchTerm: (term) => {
         set({ searchTerm: term })
     },
@@ -27,16 +27,17 @@ const useSearchStore = create((set) => ({
         set({ searchResults: results })
     },
 
-    setSearchInput: (input) => set({ searchInput: input }),
+    // Markerar om en sökning har genomförts - styr vilket UI som visas
+    setHasSearched: (bool) => set({ hasSearched: bool }),
 
-    // Återställer sökning, filter och resultat till ursprungsläget
+    // Återställer sökning, filter resultat och sökstatus till ursprungsläget
     resetSearch: () => {
-        set({ searchTerm: '', activeFilter: 'Breakfast', searchResults: [], searchInput: '' })
+        set({ searchTerm: '', activeFilter: 'Breakfast', searchResults: [], hasSearched: false })
     },
 
     setFeaturedRecipe: (recipe) => set({ featuredRecipe: recipe }),
 
-
+    // Cachar recept per kategori för att undvika onödiga API-anrop
     setCategoryCache: (category, recipes, allMealsIds) => set((state) => ({
         categoryCache: { ...state.categoryCache, [category]: {recipes, allMealsIds } }
     })),


### PR DESCRIPTION
## Refaktorering av useSearchStore

### Vad har ändrats?
- `searchInput` har tagits bort ur storen — den hör hemma som lokal state i SearchBar eftersom ingen annan komponent behöver den
- `hasSearched` har lagts till i storen istället för att leva som lokal useState i LandingPage, eftersom den styr hela sidans UI
- `setHasSearched` har lagts till som action
- `resetSearch` nollar nu `hasSearched` automatiskt — man behöver inte längre nolla den manuellt på flera ställen
- Kommentarer har lagts till på alla actions för bättre läsbarhet

### Varför?
Tidigare behövde `hasSearched` nollas manuellt på tre ställen i LandingPage 
vid varje `resetSearch`-anrop, vilket var lätt att missa. Nu sköts det 
automatiskt av storen.

`searchInput` togs bort ur storen eftersom global state ska representera 
data som delas mellan komponenter. Värdet i sökfältet är bara relevant 
för SearchBar själv och passar därför bättre som lokal useState — det 
minskar också onödiga re-renders i andra komponenter som prenumererar 
på storen.

### Påverkar
Denna branch är en förutsättning för att uppdatera `SearchBar`, `handleSearch` och `LandingPage`. Merga denna först.